### PR TITLE
Add environment variable to control MongoDB debug mode

### DIFF
--- a/src/database/connectDatabase.ts
+++ b/src/database/connectDatabase.ts
@@ -1,8 +1,10 @@
 import mongoose from "mongoose";
+import { environment } from "../loadEnvironments.js";
 
-const connectDatabase = async (mongoUrl: string) => {
-  await mongoose.connect(mongoUrl);
+const connectDatabase = async (mongoDbUrl: string) => {
+  await mongoose.connect(mongoDbUrl);
 
+  mongoose.set("debug", environment.mongoDbDebug);
   mongoose.set("toJSON", {
     virtuals: true,
     transform(doc, ret) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { mongoUrl, port } from "./loadEnvironments.js";
+import { environment } from "./loadEnvironments.js";
 import debugCreator from "debug";
 import chalk from "chalk";
 import { mongo } from "mongoose";
@@ -10,10 +10,12 @@ const debug = debugCreator("identity-server:root");
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const { MongoServerError } = mongo;
 
+const { port, mongoDbUrl } = environment;
+
 try {
   await startServer(+port);
   debug(chalk.blue(`Server listening on port ${port}`));
-  await connectDatabase(mongoUrl);
+  await connectDatabase(mongoDbUrl);
   debug(chalk.blue("Connected to database"));
 } catch (error: unknown) {
   if (error instanceof MongoServerError) {

--- a/src/loadEnvironments.ts
+++ b/src/loadEnvironments.ts
@@ -2,4 +2,14 @@ import dotenv from "dotenv";
 
 dotenv.config();
 
-export const { PORT: port, MONGODB_URL: mongoUrl } = process.env;
+const {
+  PORT: port,
+  MONGODB_URL: mongoDbUrl,
+  MONGODB_DEBUG: mongoDbDebug,
+} = process.env;
+
+export const environment = {
+  port,
+  mongoDbUrl,
+  mongoDbDebug: mongoDbDebug === "true",
+};


### PR DESCRIPTION
He añadido la opción de debug de MongoDB, que es útil para ver la comunicación con la BBDD. Es controlable desde una variable de entorno.

@catatarelli he cambiado un poco la estructura del exportador de variables de entorno, para poder meter una condición.