### PR TITLE
Feature/install config swagger

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@types/jest": "^29.2.4",
         "@types/morgan": "^1.9.3",
         "@types/supertest": "^2.0.12",
+        "@types/swagger-ui-express": "^4.1.3",
         "@typescript-eslint/eslint-plugin": "^5.42.0",
         "@typescript-eslint/parser": "^5.42.0",
         "eslint": "^8.26.0",
@@ -36,6 +37,7 @@
         "lint-staged": "^13.1.0",
         "nodemon": "^2.0.20",
         "supertest": "^6.3.3",
+        "swagger-ui-express": "^4.6.0",
         "ts-jest": "^29.0.3",
         "typescript": "^4.8.4"
       }
@@ -2830,6 +2832,16 @@
       "dev": true,
       "dependencies": {
         "@types/superagent": "*"
+      }
+    },
+    "node_modules/@types/swagger-ui-express": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@types/swagger-ui-express/-/swagger-ui-express-4.1.3.tgz",
+      "integrity": "sha512-jqCjGU/tGEaqIplPy3WyQg+Nrp6y80DCFnDEAvVKWkJyv0VivSSDCChkppHRHAablvInZe6pijDFMnavtN0vqA==",
+      "dev": true,
+      "dependencies": {
+        "@types/express": "*",
+        "@types/serve-static": "*"
       }
     },
     "node_modules/@types/webidl-conversions": {
@@ -7701,6 +7713,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swagger-ui-dist": {
+      "version": "4.15.5",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-4.15.5.tgz",
+      "integrity": "sha512-V3eIa28lwB6gg7/wfNvAbjwJYmDXy1Jo1POjyTzlB6wPcHiGlRxq39TSjYGVjQrUSAzpv+a7nzp7mDxgNy57xA==",
+      "dev": true
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.6.0.tgz",
+      "integrity": "sha512-ZxpQFp1JR2RF8Ar++CyJzEDdvufa08ujNUJgMVTMWPi86CuQeVdBtvaeO/ysrz6dJAYXf9kbVNhWD7JWocwqsA==",
+      "dev": true,
+      "dependencies": {
+        "swagger-ui-dist": ">=4.11.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0"
+      }
+    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -10622,6 +10655,16 @@
       "dev": true,
       "requires": {
         "@types/superagent": "*"
+      }
+    },
+    "@types/swagger-ui-express": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@types/swagger-ui-express/-/swagger-ui-express-4.1.3.tgz",
+      "integrity": "sha512-jqCjGU/tGEaqIplPy3WyQg+Nrp6y80DCFnDEAvVKWkJyv0VivSSDCChkppHRHAablvInZe6pijDFMnavtN0vqA==",
+      "dev": true,
+      "requires": {
+        "@types/express": "*",
+        "@types/serve-static": "*"
       }
     },
     "@types/webidl-conversions": {
@@ -14164,6 +14207,21 @@
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true
+    },
+    "swagger-ui-dist": {
+      "version": "4.15.5",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-4.15.5.tgz",
+      "integrity": "sha512-V3eIa28lwB6gg7/wfNvAbjwJYmDXy1Jo1POjyTzlB6wPcHiGlRxq39TSjYGVjQrUSAzpv+a7nzp7mDxgNy57xA==",
+      "dev": true
+    },
+    "swagger-ui-express": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.6.0.tgz",
+      "integrity": "sha512-ZxpQFp1JR2RF8Ar++CyJzEDdvufa08ujNUJgMVTMWPi86CuQeVdBtvaeO/ysrz6dJAYXf9kbVNhWD7JWocwqsA==",
+      "dev": true,
+      "requires": {
+        "swagger-ui-dist": ">=4.11.0"
+      }
     },
     "test-exclude": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@types/jest": "^29.2.4",
     "@types/morgan": "^1.9.3",
     "@types/supertest": "^2.0.12",
+    "@types/swagger-ui-express": "^4.1.3",
     "@typescript-eslint/eslint-plugin": "^5.42.0",
     "@typescript-eslint/parser": "^5.42.0",
     "eslint": "^8.26.0",
@@ -37,6 +38,7 @@
     "lint-staged": "^13.1.0",
     "nodemon": "^2.0.20",
     "supertest": "^6.3.3",
+    "swagger-ui-express": "^4.6.0",
     "ts-jest": "^29.0.3",
     "typescript": "^4.8.4"
   },

--- a/src/openapi.json
+++ b/src/openapi.json
@@ -1,0 +1,8 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Projects API",
+    "version": "1.0.0"
+  },
+  "paths": {}
+}

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -1,10 +1,12 @@
 import express from "express";
 import morgan from "morgan";
 import cors from "cors";
+import swaggerUi from "swagger-ui-express";
 import paths from "./routes/paths.js";
 import pingPongProtocolRouter from "./routes/pingPongProtocolRouter/pingPongProtocolRouter.js";
+import openApiDocument from "../openapi.json" assert { type: "json" };
 
-const { baseUrl } = paths;
+const { baseUrl, apiDocs } = paths;
 
 const app = express();
 
@@ -16,5 +18,6 @@ app.use(morgan("dev"));
 app.use(express.json());
 
 app.use(baseUrl, pingPongProtocolRouter);
+app.use(apiDocs, swaggerUi.serve, swaggerUi.setup(openApiDocument));
 
 export default app;

--- a/src/server/routes/paths.ts
+++ b/src/server/routes/paths.ts
@@ -1,5 +1,6 @@
 const paths = {
   baseUrl: "/",
+  apiDocs: "/api-docs",
 };
 
 export default paths;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "ESNext" /* Specify what module code is generated. */,
     "moduleResolution": "node" /* Specify how TypeScript looks up a file from a given module specifier. */,
     "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
+    "resolveJsonModule": true,
     "outDir": "./build/" /* Specify an output folder for all emitted files. */,
     "noEmitOnError": true /* Disable emitting files if any type checking errors are reported. */,
     "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,


### PR DESCRIPTION
Vamos a usar Swagger para generar la documentación de las APIs. Tendremos un endpoint `/api-docs` donde tendremos toda la documentación de los diferentes endpoints.