### PR TITLE
Create function loadJson to load dinamically a JSON file

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -7,6 +7,7 @@ module.exports = {
   collectCoverageFrom: [
     "src/**/*.ts",
     "!src/index.ts",
+    "!src/utils/loadJson.ts",
     "!src/server/startServer.ts",
     "!src/database/connectDatabase.ts",
   ],

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,0 +1,3 @@
+jest.mock("./utils/loadJson", () => ({
+  loadJson: () => ({}),
+}));

--- a/src/utils/loadJson.ts
+++ b/src/utils/loadJson.ts
@@ -1,0 +1,11 @@
+import fs from "fs";
+
+/* We can't use Node's import assertions to load JSON because ts-jest won't understand them
+/* This is a workaround from https://stackoverflow.com/a/73747606/574218 */
+/* It must be removed when Node's import assertions are stable */
+export const loadJson = <T>(path: string) => {
+  const url = new URL(path, import.meta.url);
+  const file = fs.readFileSync(url).toString();
+  const data = JSON.parse(file) as T;
+  return data;
+};


### PR DESCRIPTION
Para poder importar un JSON con la versión actual de Node hace falta usar [`import assertions`](https://v8.dev/features/import-assertions), pero éstos no funcionan con `ts-jest`. Temporalmente usaremos esta función que carga dinámicamente el archivo en tiempo de ejecución.