### PR TITLE
Feature/check jwt in cookie

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "bcryptjs": "^2.4.3",
+        "cookie-parser": "^1.4.6",
         "cors": "^2.8.5",
         "debug": "^4.3.4",
         "dotenv": "^16.0.3",
@@ -24,6 +25,7 @@
       "devDependencies": {
         "@faker-js/faker": "^7.6.0",
         "@types/bcryptjs": "^2.4.2",
+        "@types/cookie-parser": "^1.4.3",
         "@types/cors": "^2.8.13",
         "@types/debug": "^4.1.7",
         "@types/dotenv": "^8.2.0",
@@ -2700,6 +2702,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookie-parser": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.3.tgz",
+      "integrity": "sha512-CqSKwFwefj4PzZ5n/iwad/bow2hTCh0FlNAeWLtQM3JA/NX/iYagIpWG2cf1bQKQ2c9gU2log5VUCrn7LDOs0w==",
+      "dev": true,
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/cookiejar": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.2.tgz",
@@ -4009,6 +4020,26 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
       "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "dependencies": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -11019,6 +11050,15 @@
         "@types/node": "*"
       }
     },
+    "@types/cookie-parser": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.3.tgz",
+      "integrity": "sha512-CqSKwFwefj4PzZ5n/iwad/bow2hTCh0FlNAeWLtQM3JA/NX/iYagIpWG2cf1bQKQ2c9gU2log5VUCrn7LDOs0w==",
+      "dev": true,
+      "requires": {
+        "@types/express": "*"
+      }
+    },
     "@types/cookiejar": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.2.tgz",
@@ -12015,6 +12055,22 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
       "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
+    },
+    "cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "requires": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+          "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
+        }
+      }
     },
     "cookie-signature": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "@faker-js/faker": "^7.6.0",
     "@types/bcryptjs": "^2.4.2",
+    "@types/cookie-parser": "^1.4.3",
     "@types/cors": "^2.8.13",
     "@types/debug": "^4.1.7",
     "@types/dotenv": "^8.2.0",
@@ -51,6 +52,7 @@
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",
+    "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
     "debug": "^4.3.4",
     "dotenv": "^16.0.3",

--- a/src/server/controllers/authControllers/authControllers.ts
+++ b/src/server/controllers/authControllers/authControllers.ts
@@ -4,6 +4,7 @@ import { environment } from "../../../loadEnvironments.js";
 import CustomError from "../../../CustomError/CustomError.js";
 import httpStatusCodes from "../../../utils/httpStatusCodes.js";
 import type { CustomTokenPayload } from "../userControllers/types.js";
+import singleSignOnCookie from "../../../utils/singleSignOnCookie.js";
 
 const {
   successCodes: { okCode },
@@ -14,15 +15,17 @@ const {
   jwt: { jwtSecret },
 } = environment;
 
+const { cookieName } = singleSignOnCookie;
+
 const userAuthentication = (
   req: Request,
   res: Response,
   next: NextFunction
 ) => {
   try {
-    const authHeader = req.header("Authorization");
+    const authToken = (req.cookies as Record<string, string>)[cookieName];
 
-    if (!authHeader) {
+    if (!authToken) {
       throw new CustomError(
         "No Token provided",
         unauthorizedCode,
@@ -30,18 +33,8 @@ const userAuthentication = (
       );
     }
 
-    if (!authHeader.startsWith("Bearer")) {
-      throw new CustomError(
-        "Missing Bearer in token",
-        unauthorizedCode,
-        "Missing Bearer in token"
-      );
-    }
-
-    const token = authHeader.replace(/^Bearer\s*/, "");
-
     const verifyToken: CustomTokenPayload = jwt.verify(
-      token,
+      authToken,
       jwtSecret
     ) as CustomTokenPayload;
 

--- a/src/server/routers/verifyTokenRouter/verifyTokenRouter.test.ts
+++ b/src/server/routers/verifyTokenRouter/verifyTokenRouter.test.ts
@@ -7,8 +7,14 @@ import {
   mockTokenPayload,
 } from "../../../testUtils/mocks/mockToken.js";
 import type { CustomTokenPayload } from "../../controllers/userControllers/types.js";
+import singleSignOnCookie from "../../../utils/singleSignOnCookie.js";
 
 const { verifyToken, users } = paths;
+
+const { cookieName } = singleSignOnCookie;
+
+const correctCookie = `${cookieName}=${mockToken}`;
+const incorrectCookie = `${cookieName}=incorrect-cookie`;
 
 const {
   successCodes: { okCode },
@@ -17,9 +23,8 @@ const {
 
 describe("Given a GET /verify-token endpoint", () => {
   const expectedMessage = "Unauthorized";
-  const mockAuthorizationHeader = `Bearer ${mockToken}`;
 
-  describe("When it receives a request with no auth header", () => {
+  describe("When it receives a request with no cookie", () => {
     test("Then it should respond with status 401 and 'Unauthorized' error message ", async () => {
       const expectedStatus = unauthorizedCode;
 
@@ -33,7 +38,7 @@ describe("Given a GET /verify-token endpoint", () => {
     });
   });
 
-  describe("When it receives a request with auth header and a valid token", () => {
+  describe("When it receives a request with a cookie and a valid token", () => {
     test("Then it should respond with status 200 and userPayload in the body", async () => {
       const expectedStatus = okCode;
 
@@ -41,7 +46,7 @@ describe("Given a GET /verify-token endpoint", () => {
         body: { userPayload: CustomTokenPayload };
       } = await request(app)
         .get(`${users}${verifyToken}`)
-        .set("Authorization", mockAuthorizationHeader)
+        .set("Cookie", [correctCookie])
         .send(mockTokenPayload)
         .expect(expectedStatus);
 
@@ -57,7 +62,7 @@ describe("Given a GET /verify-token endpoint", () => {
         body: { userPayload: CustomTokenPayload };
       } = await request(app)
         .get(`${users}${verifyToken}`)
-        .set("Authorization", "Bearer #")
+        .set("Cookie", [incorrectCookie])
         .expect(expectedStatus);
 
       expect(response.body).toHaveProperty("error", expectedMessage);

--- a/src/server/routers/verifyTokenRouter/verifyTokenRouter.ts
+++ b/src/server/routers/verifyTokenRouter/verifyTokenRouter.ts
@@ -1,11 +1,13 @@
 import { Router } from "express";
+import cookieParser from "cookie-parser";
 import userAuthentication from "../../controllers/authControllers/authControllers.js";
 import paths from "../paths.js";
-
 const { verifyToken } = paths;
 
 // eslint-disable-next-line new-cap
 const verifyTokenRouter = Router();
+
+verifyTokenRouter.use(cookieParser());
 
 verifyTokenRouter.get(verifyToken, userAuthentication);
 


### PR DESCRIPTION
Actualizado el endpoint de GET /users/verify-token para parsear cookies con Express cookie-parser.

En vez que recibir el token en Authorization header, recibe el token en cookie. 