### PR TITLE
Update openapi docs security with cookie and /users/verify-token

### DIFF
--- a/src/openapi/openapi.json
+++ b/src/openapi/openapi.json
@@ -40,10 +40,10 @@
       }
     },
     "securitySchemes": {
-      "Bearer Auth": {
+      "Cookie Auth": {
         "type": "http",
-        "scheme": "bearer",
-        "bearerFormat": "JWT"
+        "name": "coders_identity_token",
+        "cookieFormat": "JWT"
       }
     },
     "responses": {
@@ -125,20 +125,18 @@
         "summary": "Verify user token",
         "security": [
           {
-            "Bearer Auth": []
+            "Cookie Auth": []
           }
         ],
         "parameters": [
           {
-            "in": "header",
-            "name": "Authorization",
+            "in": "cookie",
+            "name": "coders_identity_token",
             "required": true,
-            "description": "A valid JWT token must be passed in the 'Authorization' header.",
+            "description": "A valid JWT token must be passed in the 'coders_identity_token' cookie",
             "schema": {
               "type": "string",
-              "example": {
-                "Authorization": "Bearer xx.yy.zz"
-              }
+              "example": "coders_identity_token=xx.yy.zz"
             }
           }
         ],


### PR DESCRIPTION
He actualizado la documentacion para este endpoint. Ahora tiene un cookie con JWT como parametro obligatorio en vez que bearer token en Authorization header.