### PR TITLE
Feature/reafactor bcrypt functions

### DIFF
--- a/src/utils/PasswordHasherBcrypt/PasswordHasher.ts
+++ b/src/utils/PasswordHasherBcrypt/PasswordHasher.ts
@@ -1,0 +1,9 @@
+interface PasswordHasher {
+  passwordHash: (password: string) => Promise<string>;
+  passwordCompare: (
+    password: string,
+    hashedPassword: string
+  ) => Promise<boolean>;
+}
+
+export default PasswordHasher;

--- a/src/utils/PasswordHasherBcrypt/PasswordHasherBcrypt.test.ts
+++ b/src/utils/PasswordHasherBcrypt/PasswordHasherBcrypt.test.ts
@@ -1,0 +1,35 @@
+import PasswordHasherBcrypt from "./PasswordHasherBcrypt";
+import bcrypt from "bcryptjs";
+
+describe("Given an instance of PasswordHasherBcrypt class", () => {
+  const passwordHasher = new PasswordHasherBcrypt();
+  const password = "test-password";
+  const hashedPassword = "test-hash";
+  describe("When the method passwordHash is invoked with 'test-password' as password", () => {
+    test("Then it should return the password hashed", async () => {
+      const salt = 10;
+      jest.spyOn(bcrypt, "hash").mockImplementation(() => hashedPassword);
+
+      const returnedHashedPassword = await passwordHasher.passwordHash(
+        password
+      );
+
+      expect(bcrypt.hash).toHaveBeenCalledWith(password, salt);
+      expect(returnedHashedPassword).toBe(hashedPassword);
+    });
+  });
+
+  describe("And when the method passwordCompare is invoked with 'test-password' as password and a a valid hashed password", () => {
+    test("Then it should return true", async () => {
+      jest.spyOn(bcrypt, "compare").mockImplementation(() => true);
+
+      const resultComparison = await passwordHasher.passwordCompare(
+        password,
+        hashedPassword
+      );
+
+      expect(bcrypt.compare).toHaveBeenCalledWith(password, hashedPassword);
+      expect(resultComparison).toBe(true);
+    });
+  });
+});

--- a/src/utils/PasswordHasherBcrypt/PasswordHasherBcrypt.ts
+++ b/src/utils/PasswordHasherBcrypt/PasswordHasherBcrypt.ts
@@ -1,0 +1,18 @@
+import type PasswordHasher from "./PasswordHasher";
+import bcrypt from "bcryptjs";
+
+class PasswordHasherBcrypt implements PasswordHasher {
+  salt = 10;
+
+  async passwordHash(password: string) {
+    const hashedPassword = await bcrypt.hash(password, this.salt);
+    return hashedPassword;
+  }
+
+  async passwordCompare(password: string, hashedPassword: string) {
+    const isValidPassword = await bcrypt.compare(password, hashedPassword);
+    return isValidPassword;
+  }
+}
+
+export default PasswordHasherBcrypt;


### PR DESCRIPTION
Interfaz PasswordHasher (tengo dudas con el naming pero la idea es que, como es una abstracción, no debe limitarse a la clase que usa Bcrypt): Define que la clase que usemos para hashear y comparar passwords (hoy con implementación de Bcrypt, mañana podría ser usando otra librería), deberá tener un método passwordHash y passwordCompare.
La clase PasswordHasherBcrypt implementa la interfaz utilizando Bcrypt, sus métodos no hacen mucho más allá de llamar a los propios de Bcrypt. Clase testeada aplicando spyOn en cada método de Bcrypt en lugar de mockear el módulo entero.
UserController ahora en lugar de llamar a Bcrypt utiliza nuestra clase; test actualizado mockeando el módulo entero de nuestra clase. 