### PR TITLE
Add eslint 0 warning & delete unnecessary .css extension for prettier

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,4 +1,4 @@
 {
-  "*.ts": "eslint",
-  "*.{ts,css,json,md}": "prettier --write"
+  "*.ts": "eslint --max-warnings 0",
+  "*.{ts,json,md}": "prettier --write"
 }


### PR DESCRIPTION
Añadido a lint-stage en eslint que no permita warnings & en prettier he quitado que formate los archivos de .css porque no se iba a usar. 