### PR TITLE
Remove " and \n from joi validation error feedback

### DIFF
--- a/src/server/middlewares/errors.ts
+++ b/src/server/middlewares/errors.ts
@@ -22,8 +22,9 @@ const generalError = (
 ) => {
   if (error instanceof ValidationError) {
     const validationErrors = error.details.body
-      .map((joiError) => joiError.message)
-      .join("\n");
+      // eslint-disable-next-line no-useless-escape
+      .map((joiError) => joiError.message.replaceAll(`\"`, ""))
+      .join(" & ");
 
     error.publicMessage = validationErrors;
 

--- a/src/server/routers/usersRouter/usersRouter.test.ts
+++ b/src/server/routers/usersRouter/usersRouter.test.ts
@@ -95,7 +95,7 @@ describe("Given a POST /users/register endpoint", () => {
       const expectedMessage = [
         "Name shouldn't be empty",
         "Email shouldn't be empty",
-      ].join("\n");
+      ].join(" & ");
 
       const response = await request(app)
         .post(`${users}${register}`)
@@ -198,7 +198,7 @@ describe("Given a POST /users/login endpoint", () => {
   describe("When it receives a request with invalid email 'luisito' and short password 'luisito'", () => {
     test("Then it should respond with status 400 and the errors 'Email must be a valid email'", async () => {
       const expectedErrors = {
-        error: ['"Email" must be a valid email'].join("\n"),
+        error: ["Email must be a valid email"].join(" & "),
       };
       const email = "luisito";
       const password = "luisito";


### PR DESCRIPTION
He limpiado el feedback de los errores de validación de JOI

Ahora en vez que responder con: 

`{"error": "\"email\" must be a valid email address\n\"password\" is required"}`

ahora responderá con:

`{"error": "email must be a valid email address & password is required"}`
