### PR TITLE
Feature/cod 71 refactor namespace debug

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -28,6 +28,7 @@ jobs:
           SMTP_PASSWORD: ${{ secrets.SMTP_PASSWORD }}
           EMAIL_SENDER: ${{ secrets.JWT_SECRET }}
           TOKEN_EXPIRY: ${{ secrets.TOKEN_EXPIRY}}
+          APP_NAME: ${{ secrets.APP_NAME}}
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master
         env:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -27,3 +27,4 @@ jobs:
           SMTP_PASSWORD: ${{ secrets.SMTP_PASSWORD }}
           EMAIL_SENDER: ${{ secrets.JWT_SECRET }}
           TOKEN_EXPIRY: ${{ secrets.TOKEN_EXPIRY}}
+          APP_NAME: ${{ secrets.APP_NAME}}

--- a/src/email/sendEmail/sendEmail.ts
+++ b/src/email/sendEmail/sendEmail.ts
@@ -1,5 +1,5 @@
 import transporter from "../transporter.js";
-import debugConfig from "debug";
+import debugConfig from "../../utils/debugConfig.js";
 import chalk from "chalk";
 import { environment } from "../../loadEnvironments.js";
 import type { EmailOptions } from "../types.js";
@@ -9,7 +9,7 @@ const {
   smtp: { emailSender },
 } = environment;
 
-const debug = debugConfig("identity-server:email");
+const debug = debugConfig.extend("email");
 
 const sendEmail = async ({
   to,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,12 @@
 import { environment } from "./loadEnvironments.js";
-import debugCreator from "debug";
+import debugConfig from "./utils/debugConfig.js";
 import chalk from "chalk";
 import { mongo } from "mongoose";
 import startServer from "./server/startServer.js";
 import connectDatabase from "./database/connectDatabase.js";
 import type CustomError from "./CustomError/CustomError.js";
 
-const debug = debugCreator("identity-server:root");
+const debug = debugConfig.extend("root");
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const { MongoServerError } = mongo;

--- a/src/loadEnvironments.ts
+++ b/src/loadEnvironments.ts
@@ -16,6 +16,7 @@ const {
   SMTP_PASSWORD: smtpPassword,
   EMAIL_SENDER: emailSender,
   TOKEN_EXPIRY: tokenExpiry,
+  APP_NAME: appName,
 } = process.env;
 
 export const environment = {
@@ -38,4 +39,5 @@ export const environment = {
     port: +smtpPort,
     emailSender,
   },
+  appName,
 };

--- a/src/server/middlewares/errors.ts
+++ b/src/server/middlewares/errors.ts
@@ -1,5 +1,5 @@
 import "../../loadEnvironments.js";
-import debugCreator from "debug";
+import debugConfig from "../../utils/debugConfig.js";
 import chalk from "chalk";
 import type { NextFunction, Request, Response } from "express";
 import { ValidationError } from "express-validation";
@@ -11,7 +11,7 @@ const {
   clientErrors: { notFoundCode },
 } = httpStatusCodes;
 
-const debug = debugCreator("identity-server:middlewares:errors");
+const debug = debugConfig.extend("middlewares:errors");
 
 const generalError = (
   error: CustomError,

--- a/src/utils/debugConfig.ts
+++ b/src/utils/debugConfig.ts
@@ -1,0 +1,11 @@
+import configureDebug from "debug";
+import { environment } from "../loadEnvironments.js";
+
+const debugCreator = () => configureDebug(environment.appName);
+
+const debugConfig = debugCreator();
+
+const localDebug = debugConfig.extend("debug-creator");
+localDebug("Debug created");
+
+export default debugConfig;


### PR DESCRIPTION
He creado el archivo debugConfig.js.

He visto que importamos debug en muchos sitios y en la documentacion hay una opcion para extender debugs.

Ahora para usar debug tenemos que hacer esto:

```
import debugConfig from "src/utils/debugConfig.js";

const debug = debugConfig.extend("<lo-que-sea>");

debug("Lo que quieres imprimir con debug);
```

Saldra por consola como:

`app-name:lo-que-sea`

Por defecto el delimitador de extend es ":" pero si lo quieres cambiar lo puedes pasar como segundo argumento.

Ahora solo hacemos un import del paquete debug en toda la aplicacion y podemos extender el namespace para los modulos donde vamos a usarlo.

@coders-app/devs Opiniones?

Al final he metido el namespace por .env con el nombre APP_NAME

Entonces tenemos que actualizar el .env en Render, GitHub y en nuestras maquinas.