### PR TITLE
Refactor debugConfig and renamed localDebug

### DIFF
--- a/src/utils/debugConfig.ts
+++ b/src/utils/debugConfig.ts
@@ -1,11 +1,9 @@
 import configureDebug from "debug";
 import { environment } from "../loadEnvironments.js";
 
-const debugCreator = () => configureDebug(environment.appName);
+const debugConfig = configureDebug(environment.appName);
 
-const debugConfig = debugCreator();
-
-const localDebug = debugConfig.extend("debug-creator");
-localDebug("Debug created");
+const debug = debugConfig.extend("debug-creator");
+debug("Debug created");
 
 export default debugConfig;


### PR DESCRIPTION
Pequeño refactor del debugConfig, he eliminado una llamada innecesaria a una función y he renombrado una variable por mejorar el naming.