### PR TITLE
Feature/cod 122 create auth middleware

### DIFF
--- a/src/server/controllers/userControllers/userControllers.test.ts
+++ b/src/server/controllers/userControllers/userControllers.test.ts
@@ -2,11 +2,16 @@ import jwt from "jsonwebtoken";
 import type { NextFunction, Request, Response } from "express";
 import User from "../../../database/models/User.js";
 import httpStatusCodes from "../../../constants/statusCodes/httpStatusCodes.js";
-import { activateUser, loginUser, registerUser } from "./userControllers.js";
+import {
+  activateUser,
+  getUserDetails,
+  loginUser,
+  registerUser,
+} from "./userControllers.js";
 import CustomError from "../../../CustomError/CustomError.js";
 import { mockToken } from "../../../testUtils/mocks/mockToken.js";
 import { luisEmail } from "../../../testUtils/mocks/mockUsers.js";
-import type { UserWithId } from "../../types.js";
+import type { CustomRequest, UserWithId } from "../../types.js";
 import { getMockUserData } from "../../../factories/userDataFactory.js";
 import { getMockUser } from "../../../factories/userFactory.js";
 import { getMockUserCredentials } from "../../../factories/userCredentialsFactory.js";
@@ -260,6 +265,27 @@ describe("Given an activateUser function", () => {
       await activateUser(req as Request, null, next);
 
       expect(next).toHaveBeenCalledWith(invalidKeyError);
+    });
+  });
+});
+
+describe("Given a getUserDetails controller", () => {
+  describe("When it receives a CustomRequest with user details id: '1234', name: 'Fulanito', and isAdmin 'false'", () => {
+    test("Then it should invoke response's method status with 200 and json with with received user details", () => {
+      const userDetails = {
+        id: "1234",
+        name: "Fulanito",
+        isAdmin: false,
+      };
+
+      const req: Partial<CustomRequest> = {
+        userDetails,
+      };
+
+      getUserDetails(req as CustomRequest, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(okCode);
+      expect(res.json).toHaveBeenCalledWith({ userPayload: userDetails });
     });
   });
 });

--- a/src/server/controllers/userControllers/userControllers.ts
+++ b/src/server/controllers/userControllers/userControllers.ts
@@ -5,6 +5,7 @@ import User from "../../../database/models/User.js";
 import httpStatusCodes from "../../../constants/statusCodes/httpStatusCodes.js";
 import { environment } from "../../../loadEnvironments.js";
 import type {
+  CustomRequest,
   CustomTokenPayload,
   UserActivationCredentials,
   UserCredentials,
@@ -195,4 +196,10 @@ export const activateUser = async (
   } catch (error: unknown) {
     next(error);
   }
+};
+
+export const getUserDetails = (req: CustomRequest, res: Response) => {
+  const { id, isAdmin, name } = req.userDetails;
+
+  res.status(okCode).json({ userPayload: { name, isAdmin, id } });
 };

--- a/src/server/middlewares/auth/auth.ts
+++ b/src/server/middlewares/auth/auth.ts
@@ -1,15 +1,10 @@
-import type { NextFunction, Request, Response } from "express";
 import jwt from "jsonwebtoken";
-import { environment } from "../../../loadEnvironments.js";
+import type { NextFunction, Response } from "express";
+import type { CustomRequest, CustomTokenPayload } from "../../types";
+import config from "../../../config.js";
 import CustomError from "../../../CustomError/CustomError.js";
 import httpStatusCodes from "../../../constants/statusCodes/httpStatusCodes.js";
-import type { CustomTokenPayload } from "../../types.js";
-import config from "../../../config.js";
-
-const {
-  successCodes: { okCode },
-  clientErrors: { unauthorizedCode },
-} = httpStatusCodes;
+import { environment } from "../../../loadEnvironments.js";
 
 const {
   jwt: { jwtSecret },
@@ -19,11 +14,11 @@ const {
   singleSignOnCookie: { cookieName },
 } = config;
 
-const userAuthentication = (
-  req: Request,
-  res: Response,
-  next: NextFunction
-) => {
+const {
+  clientErrors: { unauthorizedCode },
+} = httpStatusCodes;
+
+const auth = (req: CustomRequest, res: Response, next: NextFunction) => {
   try {
     const authToken = (req.cookies as Record<string, string>)[cookieName];
 
@@ -50,7 +45,9 @@ const userAuthentication = (
 
     const { name, isAdmin, id } = verifyToken;
 
-    res.status(okCode).json({ userPayload: { name, isAdmin, id } });
+    req.userDetails = { name, isAdmin, id };
+
+    next();
   } catch (error: unknown) {
     const customError = new CustomError(
       (error as Error).message,
@@ -62,4 +59,4 @@ const userAuthentication = (
   }
 };
 
-export default userAuthentication;
+export default auth;

--- a/src/server/routers/usersRouter/usersRouter.ts
+++ b/src/server/routers/usersRouter/usersRouter.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 import { validate } from "express-validation";
 import {
   activateUser,
+  getUserDetails,
   loginUser,
   registerUser,
 } from "../../controllers/userControllers/userControllers.js";
@@ -11,7 +12,7 @@ import activateUserSchema from "../../schemas/activateUserSchema.js";
 import { noAbortEarly } from "../../schemas/validateOptions.js";
 import { partialPaths } from "../paths.js";
 import cookieParser from "cookie-parser";
-import userAuthentication from "../../controllers/authControllers/authControllers.js";
+import auth from "../../middlewares/auth/auth.js";
 
 // eslint-disable-next-line new-cap
 const usersRouter = Router();
@@ -36,6 +37,6 @@ usersRouter.post(
 
 usersRouter.use(cookieParser());
 
-usersRouter.get(partialPaths.users.verifyToken, userAuthentication);
+usersRouter.get(partialPaths.users.verifyToken, auth, getUserDetails);
 
 export default usersRouter;

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -1,3 +1,5 @@
+import type * as core from "express-serve-static-core";
+import type { Request } from "express";
 import type { JwtPayload } from "jsonwebtoken";
 
 export interface UserCredentials {
@@ -28,4 +30,16 @@ export interface CustomTokenPayload
 
 export interface UserWithId extends UserStructure {
   _id: string;
+}
+
+export interface CustomRequest<
+  P = core.ParamsDictionary,
+  ResBody = any,
+  ReqBody = any
+> extends Request<P, ResBody, ReqBody> {
+  userDetails: {
+    id: string;
+    isAdmin: boolean;
+    name: string;
+  };
 }


### PR DESCRIPTION
Vi que el controller `userAuthentication` tenia la responsibilidad de extraer el token de la cookie, decodificarlo y responder con los datos del usuario. 

Como necesitamos en otras partes decodificar el JWT pero no responder con los datos, he extraido la responsibilidad de coger el token del cookie y decodificarlo a un middleware que se llama auth. Auth añade los datos de usuario al request. Tambien he creado un CustomRequest.

He borrado el userAuthentication controller y creado uno que se llama getUserDetails, porque solo responde con los datos ya extraidos por el middleware auth. 

Tambien he testeado auth y getUserDetails