### PR TITLE
Add install dependencies when there are diff in HEAD and always exit 0

### DIFF
--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,4 +1,10 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-git diff HEAD~ HEAD --name-only | grep -E '^(package-lock\.json|yarn\.lock)$'
+if git diff HEAD~ HEAD --name-only | grep -E '^(package-lock\.json|yarn\.lock)$';
+then 
+    npm i
+    echo -e "Detected changes in dependencies, executing npm install..." 
+fi
+
+exit 0

--- a/package-lock.json
+++ b/package-lock.json
@@ -12072,7 +12072,7 @@
     },
     "coders-app-api-key-authenticator": {
       "version": "git+ssh://git@github.com/coders-app/coders-app-api-key-authenticator.git#2afb9ed74446e0e10b0a5b9829147a04a81a207f",
-      "from": "coders-app-api-key-authenticator@https://github.com/coders-app/coders-app-api-key-authenticator/",
+      "from": "coders-app-api-key-authenticator@github:coders-app/coders-app-api-key-authenticator",
       "requires": {
         "bcryptjs": "^2.4.3",
         "dotenv": "^16.0.3",


### PR DESCRIPTION
Le faltaba añadir un if para comprobar si había diferencias respecto el head, un then para instalar las dependencias, el fi es para acabar. 
Y siempre en todos los casos va a salir con un exit 0 para que no genere errores. 