### PR TITLE
Bugfix/set headers credentials tests

### DIFF
--- a/src/constants/requestHeaders.ts
+++ b/src/constants/requestHeaders.ts
@@ -1,6 +1,7 @@
 const requestHeaders = {
   apiKeyHeader: "X-API-KEY",
   apiNameHeader: "X-API-NAME",
+  allowCredentials: "Access-Control-Allow-Credentials",
 };
 
 export default requestHeaders;

--- a/src/server/middlewares/setHeaderCredentials/setHeaderCredentials.test.ts
+++ b/src/server/middlewares/setHeaderCredentials/setHeaderCredentials.test.ts
@@ -1,22 +1,31 @@
 import type { Request, Response, NextFunction } from "express";
+import requestHeaders from "../../../constants/requestHeaders";
 import setHeaderCredentials from "./setHeaderCredentials";
 
+const { allowCredentials } = requestHeaders;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
 describe("Given a setHeaderCredentials middleware", () => {
-  describe("When it receives a request, response and next function", () => {
-    test("Then it should invoke response's method header with 'Access-Control-Allow-Credentials', 'true' and next function", () => {
-      const req: Partial<Request> = {};
-      const res: Partial<Response> = {
-        header: jest.fn(),
-      };
+  const req: Partial<Request> = {};
+  const res: Partial<Response> = {
+    header: jest.fn(),
+  };
 
-      const next: NextFunction = jest.fn();
+  const next: NextFunction = jest.fn();
 
+  describe("When it receives a response and next function", () => {
+    test("Then it should invoke response's method header with 'Access-Control-Allow-Credentials', 'true'", () => {
       setHeaderCredentials(req as Request, res as Response, next);
 
-      expect(res.header).toHaveBeenCalledWith(
-        "Access-Control-Allow-Credentials",
-        "true"
-      );
+      expect(res.header).toHaveBeenCalledWith(allowCredentials, "true");
+    });
+
+    test("Then it should invoke next function", () => {
+      setHeaderCredentials(req as Request, res as Response, next);
+
       expect(next).toHaveBeenCalled();
     });
   });

--- a/src/server/middlewares/setHeaderCredentials/setHeaderCredentials.ts
+++ b/src/server/middlewares/setHeaderCredentials/setHeaderCredentials.ts
@@ -1,11 +1,14 @@
 import type { Request, Response, NextFunction } from "express";
+import requestHeaders from "../../../constants/requestHeaders.js";
+
+const { allowCredentials } = requestHeaders;
 
 const setHeaderCredentials = (
   req: Request,
   res: Response,
   next: NextFunction
 ) => {
-  res.header("Access-Control-Allow-Credentials", "true");
+  res.header(allowCredentials, "true");
 
   next();
 };


### PR DESCRIPTION
Separado expects setHeaderCredentials en 2 expects y añadido los cambios requeridos en PR de Api-Gateway: https://github.com/coders-app/coders-app-api-gateway/pull/35

Añadido allowCredentials al archivo de requestHeaders