### PR TITLE
Add SameSite:'none' to token cookie

### DIFF
--- a/src/server/controllers/userControllers/userControllers.test.ts
+++ b/src/server/controllers/userControllers/userControllers.test.ts
@@ -166,6 +166,8 @@ describe("Given a loginUser controller", () => {
       expect(res.cookie).toHaveBeenCalledWith(cookieName, mockToken, {
         httpOnly: true,
         maxAge: cookieMaxAge,
+        sameSite: "none",
+        secure: true,
       });
       expect(res.json).toHaveBeenCalledWith({
         message: "coders_identity_token has been set",

--- a/src/server/controllers/userControllers/userControllers.ts
+++ b/src/server/controllers/userControllers/userControllers.ts
@@ -137,6 +137,8 @@ export const loginUser = async (
       .cookie(cookieName, token, {
         httpOnly: true,
         maxAge: cookieMaxAge,
+        sameSite: "none",
+        secure: true,
       })
       .json({ message: `${cookieName} has been set` });
   } catch (error: unknown) {


### PR DESCRIPTION
Se ha añadido a la cookie securizada los flags `Secure` y `SameSite: none` para que el navegador no la bloquee.