### PR TITLE
Feature/cod 149 refactor payload token

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
         "@types/bcryptjs": "^2.4.2",
         "@types/cookie-parser": "^1.4.3",
         "@types/debug": "^4.1.7",
-        "@types/dotenv": "^8.2.0",
         "@types/express": "^4.17.15",
         "@types/jest": "^29.2.4",
         "@types/jsonwebtoken": "^9.0.0",
@@ -3080,16 +3079,6 @@
         "@types/ms": "*"
       }
     },
-    "node_modules/@types/dotenv": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@types/dotenv/-/dotenv-8.2.0.tgz",
-      "integrity": "sha512-ylSC9GhfRH7m1EUXBXofhgx4lUWmFeQDINW5oLuS+gxWdfUeW4zJdeVTYVkexEW+e2VUvlZR2kGnGGipAWR7kw==",
-      "deprecated": "This is a stub types definition. dotenv provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "dotenv": "*"
-      }
-    },
     "node_modules/@types/express": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.15.tgz",
@@ -4330,7 +4319,7 @@
     },
     "node_modules/coders-app-api-key-authenticator": {
       "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/coders-app/coders-app-api-key-authenticator.git#2afb9ed74446e0e10b0a5b9829147a04a81a207f",
+      "resolved": "git+ssh://git@github.com/coders-app/coders-app-api-key-authenticator.git#02d15da84e33e9da8123b5f79b3bafa25224ff94",
       "license": "ISC",
       "dependencies": {
         "bcryptjs": "^2.4.3",
@@ -12627,15 +12616,6 @@
         "@types/ms": "*"
       }
     },
-    "@types/dotenv": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@types/dotenv/-/dotenv-8.2.0.tgz",
-      "integrity": "sha512-ylSC9GhfRH7m1EUXBXofhgx4lUWmFeQDINW5oLuS+gxWdfUeW4zJdeVTYVkexEW+e2VUvlZR2kGnGGipAWR7kw==",
-      "dev": true,
-      "requires": {
-        "dotenv": "*"
-      }
-    },
     "@types/express": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.15.tgz",
@@ -13563,7 +13543,7 @@
       "dev": true
     },
     "coders-app-api-key-authenticator": {
-      "version": "git+ssh://git@github.com/coders-app/coders-app-api-key-authenticator.git#2afb9ed74446e0e10b0a5b9829147a04a81a207f",
+      "version": "git+ssh://git@github.com/coders-app/coders-app-api-key-authenticator.git#02d15da84e33e9da8123b5f79b3bafa25224ff94",
       "from": "coders-app-api-key-authenticator@github:coders-app/coders-app-api-key-authenticator",
       "requires": {
         "bcryptjs": "^2.4.3",

--- a/src/server/controllers/userControllers/userControllers.test.ts
+++ b/src/server/controllers/userControllers/userControllers.test.ts
@@ -257,8 +257,6 @@ describe("Given a getUserDetails controller", () => {
     test("Then it should invoke response's method status with 200 and json with with received user details", () => {
       const userDetails = {
         id: "1234",
-        name: "Fulanito",
-        isAdmin: false,
       };
 
       const req: Partial<CustomRequest> = {
@@ -292,8 +290,6 @@ describe("Given a getUserData controller", () => {
   const req: Partial<CustomRequest> = {
     userDetails: {
       id: user._id,
-      isAdmin: user.isAdmin,
-      name: user.name,
     },
   };
 

--- a/src/server/controllers/userControllers/userControllers.ts
+++ b/src/server/controllers/userControllers/userControllers.ts
@@ -105,8 +105,6 @@ export const loginUser = async (
     }
 
     const tokenPayload: CustomTokenPayload = {
-      name: user.name,
-      isAdmin: user.isAdmin,
       id: user._id.toString(),
     };
 
@@ -174,9 +172,9 @@ export const activateUser = async (
 };
 
 export const getUserDetails = (req: CustomRequest, res: Response) => {
-  const { id, isAdmin, name } = req.userDetails;
+  const { id } = req.userDetails;
 
-  res.status(okCode).json({ userPayload: { name, isAdmin, id } });
+  res.status(okCode).json({ userPayload: { id } });
 };
 
 export const logoutUser = (req: Request, res: Response) => {

--- a/src/server/middlewares/auth/auth.test.ts
+++ b/src/server/middlewares/auth/auth.test.ts
@@ -55,9 +55,9 @@ describe("Given the auth middleware", () => {
   });
 
   describe("When it receives a request with a cookie that has a valid token", () => {
-    test("Then it should add id, name and isAdmin to userDetails in the request", () => {
+    test("Then it should add the user id to userDetails in the request", () => {
       const mockVerifyToken = mockTokenPayload;
-      const { id, isAdmin, name } = mockTokenPayload;
+      const { id } = mockTokenPayload;
 
       jwt.verify = jest.fn().mockReturnValue(mockVerifyToken);
       req.cookies = cookies;
@@ -65,8 +65,6 @@ describe("Given the auth middleware", () => {
       auth(req as CustomRequest, null, next);
 
       expect(req.userDetails).toHaveProperty("id", id);
-      expect(req.userDetails).toHaveProperty("name", name);
-      expect(req.userDetails).toHaveProperty("isAdmin", isAdmin);
     });
 
     test("Then it should invoke next", () => {

--- a/src/server/middlewares/auth/auth.ts
+++ b/src/server/middlewares/auth/auth.ts
@@ -1,9 +1,9 @@
-import jwt from "jsonwebtoken";
 import type { NextFunction, Response } from "express";
-import type { CustomRequest, CustomTokenPayload } from "../../types";
+import jwt from "jsonwebtoken";
 import config from "../../../config.js";
-import { environment } from "../../../loadEnvironments.js";
 import authErrors from "../../../constants/errors/authErrors.js";
+import { environment } from "../../../loadEnvironments.js";
+import type { CustomRequest, CustomTokenPayload } from "../../types";
 
 const {
   jwt: { jwtSecret },
@@ -25,10 +25,6 @@ const auth = (req: CustomRequest, res: Response, next: NextFunction) => {
       authToken,
       jwtSecret
     ) as CustomTokenPayload;
-
-    if (!verifyToken.id) {
-      throw authErrors.generalAuthError(verifyToken.message);
-    }
 
     const { id } = verifyToken;
 

--- a/src/server/middlewares/auth/auth.ts
+++ b/src/server/middlewares/auth/auth.ts
@@ -26,13 +26,13 @@ const auth = (req: CustomRequest, res: Response, next: NextFunction) => {
       jwtSecret
     ) as CustomTokenPayload;
 
-    if (verifyToken.name.includes("Error")) {
+    if (!verifyToken.id) {
       throw authErrors.generalAuthError(verifyToken.message);
     }
 
-    const { name, isAdmin, id } = verifyToken;
+    const { id } = verifyToken;
 
-    req.userDetails = { name, isAdmin, id };
+    req.userDetails = { id };
 
     next();
   } catch (error: unknown) {

--- a/src/server/routers/usersRouter/usersRouter.test.ts
+++ b/src/server/routers/usersRouter/usersRouter.test.ts
@@ -194,7 +194,7 @@ describe("Given a POST /users/login endpoint", () => {
 
   describe("When it receives a request with email 'luisito@isdicoders.com', a correct password and the user is registered and active and it receives a correct api key in the header 'X-API-KEY' and 'api-gateway' in the header 'X-API-NAME'", () => {
     test("Then it should respond with status 200 and a Set-cookie header with a token", async () => {
-      const { email, password, name } = luisitoUser;
+      const { email, password } = luisitoUser;
 
       const response = await request(app)
         .post(paths.users.login)
@@ -216,7 +216,6 @@ describe("Given a POST /users/login endpoint", () => {
         "id",
         luisitoId.toString()
       );
-      expect(tokenPayload as CustomTokenPayload).toHaveProperty("name", name);
     });
   });
 

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -22,9 +22,7 @@ export interface UserStructure
   isActive: boolean;
   activationKey: string;
 }
-export interface CustomTokenPayload
-  extends Pick<UserStructure, "name" | "isAdmin">,
-    JwtPayload {
+export interface CustomTokenPayload extends JwtPayload {
   id: string;
 }
 
@@ -39,7 +37,5 @@ export interface CustomRequest<
 > extends Request<P, ResBody, ReqBody> {
   userDetails: {
     id: string;
-    isAdmin: boolean;
-    name: string;
   };
 }

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -1,5 +1,5 @@
-import type * as core from "express-serve-static-core";
 import type { Request } from "express";
+import type * as core from "express-serve-static-core";
 import type { JwtPayload } from "jsonwebtoken";
 
 export interface UserCredentials {
@@ -15,6 +15,7 @@ export interface UserActivationCredentials
 export interface UserData extends Omit<UserCredentials, "password"> {
   name: string;
 }
+
 export interface UserStructure
   extends UserData,
     Pick<UserCredentials, "password"> {
@@ -22,6 +23,7 @@ export interface UserStructure
   isActive: boolean;
   activationKey: string;
 }
+
 export interface CustomTokenPayload extends JwtPayload {
   id: string;
 }

--- a/src/testUtils/mocks/mockToken.ts
+++ b/src/testUtils/mocks/mockToken.ts
@@ -8,8 +8,6 @@ const {
 } = environment;
 
 export const mockTokenPayload: CustomTokenPayload = {
-  name: "admin",
-  isAdmin: false,
   id: new mongoose.Types.ObjectId().toString(),
 };
 


### PR DESCRIPTION
- Refactor CustomTokenPayload y mockTokenPayload eliminando sus propiedades name e isAdmin
- Modificar verifyToken guard cuando no tiene un id valido, esto sucede por el tipado que tiene puesto el CustomTokenPayload que no contiene los tipados del `JsonWebTokenError` el cual tiene como propiedades name y message que son las que se deberian de comprobar para el throw del error